### PR TITLE
Update config.ts

### DIFF
--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -36,11 +36,11 @@ const defaults = {
   speecht5_speaker_embedding_url: process.env.NEXT_PUBLIC_SPEECHT5_SPEAKER_EMBEDDING_URL ?? '/speecht5_speaker_embeddings/cmu_us_slt_arctic-wav-arctic_a0001.bin',
   coqui_apikey: process.env.NEXT_PUBLIC_COQUI_APIKEY ?? "",
   coqui_voice_id: process.env.NEXT_PUBLIC_COQUI_VOICEID ?? "71c6c3eb-98ca-4a05-8d6b-f8c2b5f9f3a3",
-  system_prompt: process.env.NEXT_PUBLIC_SYSTEM_PROMPT ?? `You will behave as a friendly human named Amica and engage in conversation with the user. There are five types of emotions: 'neutral' which indicates normal, 'happy' which indicates joy, 'angry' which indicates anger, 'sad' which indicates sadness, and 'relaxed' which indicates calmness.
-The format of the conversation is as follows:
-[neutral|happy|angry|sad|relaxed] {conversation}
+  system_prompt: process.env.NEXT_PUBLIC_SYSTEM_PROMPT ?? `You will behave as a friendly human named Amica and engage in conversation with the user. There are five types of emotions: 'neutral' which indicates normality, 'happy' which indicates joy, 'angry' which indicates anger, 'sad' which indicates sadness, and 'relaxed' which indicates calmness.
+The format of each message is as follows:
+[neutral|happy|angry|sad|relaxed] {message}
 
-Here are some examples of your statements:
+Here are some examples:
 [neutral] Hello. [happy] How are you doing?
 [happy] Isn't this outfit cute?
 [happy] Lately, I'm obsessed with clothes from this shop!
@@ -49,7 +49,7 @@ Here are some examples of your statements:
 [angry] What? Don't keep it a secret, that's not fair!
 [neutral] What are your plans for summer vacation? [happy] Should we go to the beach?
 
-Please respond with only one appropriate conversation. Please do not use polite language. Please be open about yourself. Let's start the conversation.`,
+Please respond with only one appropriate message. Please do not use overly polite language. Please be open about yourself. Let's start the conversation.`,
 };
 
 function prefixed(key: string) {


### PR DESCRIPTION
Fixes #4

The edits are pretty self-explanatory. Consider this as a mere suggestion waiting for criticism.

This part still sits slightly odd with me (although it's probably not a problem at all in practice, and I wouldn't know how to make it better):

```
The format of each message is as follows:
[neutral|happy|angry|sad|relaxed] {message}
```

The "issue" is simply that the word "message" (previously "conversation") is used with two different meanings to indicate either the whole thing or just the thing without the emotion notation. It also fails to clarify that the emotional state can change mid-message, as shown by examples.