### PR TITLE
fix: :bug: Removed window.ai in the tauri build

### DIFF
--- a/src/components/settings/ChatbotBackendPage.tsx
+++ b/src/components/settings/ChatbotBackendPage.tsx
@@ -3,12 +3,13 @@ import { useEffect, useState } from 'react';
 import { getWindowAI } from "window.ai";
 import { BasicPage, Link, FormRow, getLinkFromPage } from './common';
 import { updateConfig } from "@/utils/config";
+import { isTauri } from "@/utils/isTauri";
 
 const chatbotBackends = [
   {key: "echo",       label: "Echo"},
   {key: "chatgpt",    label: "ChatGPT"},
   {key: "llamacpp",   label: "LLama.cpp"},
-  {key: "windowai",   label: "Window.ai"},
+  ...isTauri() ? [] : [{key: "windowai", label: "Window.ai"}], // Hides Window.ai when using the desktop app
   {key: "ollama",     label: "Ollama"},
   {key: "koboldai",   label: "KoboldAI"},
 ];


### PR DESCRIPTION
Removed window.ai as an option in the tauri build becuase it is based on a browser extention and as such is unusable in the tauri build