### PR TITLE
feature: Add FastAPI support with conditional endpoint routing

### DIFF
--- a/src/components/settings.tsx
+++ b/src/components/settings.tsx
@@ -137,6 +137,7 @@ export const Settings = ({
   const [localXTTSUrl, setLocalXTTSUrl] = useState(config("localXTTS_url"));
 
   const [kokoroUrl, setKokoroUrl] = useState(config("kokoro_url"));
+  const [kokoroApiType, setKokoroApiType] = useState(config("kokoro_api_type"));
   const [kokoroVoice, setKokoroVoice] = useState(config("kokoro_voice"));
 
   const [visionBackend, setVisionBackend] = useState(config("vision_backend"));
@@ -591,9 +592,11 @@ export const Settings = ({
     case 'kokoro_settings':
       return <KokoroSettingsPage
         kokoroUrl={kokoroUrl}
+        kokoroApiType={kokoroApiType}
         kokoroVoice={kokoroVoice}
         setKokoroVoice={setKokoroVoice}
         setKokoroUrl={setKokoroUrl}
+        setKokoroApiType={setKokoroApiType}
         setSettingsUpdated={setSettingsUpdated}
         />
 

--- a/src/components/settings.tsx
+++ b/src/components/settings.tsx
@@ -73,6 +73,7 @@ import { useVrmStoreContext } from "@/features/vrmStore/vrmStoreContext";
 import { OpenRouterSettings } from "./settings/OpenRouterSettingsPage";
 import { ExternalAPIPage } from "./settings/ExternalAPIPage";
 import { KokoroSettingsPage } from "./settings/KokoroSettingsPage";
+import type { KokoroApiType } from "@/features/kokoro/kokoro";
 
 
 export const Settings = ({
@@ -137,7 +138,9 @@ export const Settings = ({
   const [localXTTSUrl, setLocalXTTSUrl] = useState(config("localXTTS_url"));
 
   const [kokoroUrl, setKokoroUrl] = useState(config("kokoro_url"));
-  const [kokoroApiType, setKokoroApiType] = useState(config("kokoro_api_type"));
+  const [kokoroApiType, setKokoroApiType] = useState<KokoroApiType>(
+    config("kokoro_api_type") === "fastapi" ? "fastapi" : "standard"
+  );
   const [kokoroVoice, setKokoroVoice] = useState(config("kokoro_voice"));
 
   const [visionBackend, setVisionBackend] = useState(config("vision_backend"));

--- a/src/components/settings.tsx
+++ b/src/components/settings.tsx
@@ -286,10 +286,10 @@ export const Settings = ({
     speechT5SpeakerEmbeddingsUrl,
     openAITTSApiKey, openAITTSUrl, openAITTSModel, openAITTSVoice,
     piperUrl,
-    rvcUrl,rvcEnabled,rvcModelName,rvcIndexPath,rvcF0upKey,rvcF0Method,rvcIndexRate,rvcFilterRadius,,rvcResampleSr,rvcRmsMixRate,rvcProtect,
+    rvcUrl,rvcEnabled,rvcModelName,rvcIndexPath,rvcF0upKey,rvcF0Method,rvcIndexRate,rvcFilterRadius,rvcResampleSr,rvcRmsMixRate,rvcProtect,
     coquiLocalUrl,coquiLocalVoiceId,
     localXTTSUrl,
-    kokoroUrl, kokoroVoice,
+    kokoroUrl, kokoroVoice, kokoroApiType,
     visionBackend,
     visionLlamaCppUrl,
     visionOllamaUrl, visionOllamaModel,
@@ -307,6 +307,7 @@ export const Settings = ({
     systemPrompt,
     debugGfx, mtoonDebugMode, mtoonMaterialType, useWebGPU,
     sttWakeWordEnabled, sttWakeWord,
+    settingsUpdated,
   ]);
 
   useEffect(() => {

--- a/src/components/settings/KokoroSettingsPage.tsx
+++ b/src/components/settings/KokoroSettingsPage.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { BasicPage, FormRow, NotUsingAlert } from './common';
 import { TextInput } from "@/components/textInput";
 import { config, updateConfig } from "@/utils/config";
-import { kokoroVoiceList } from '@/features/kokoro/kokoro';
+import { kokoroVoiceList, type ApiType } from '@/features/kokoro/kokoro';
 
 export function KokoroSettingsPage({
   kokoroUrl,
@@ -16,11 +16,11 @@ export function KokoroSettingsPage({
 }: {
   kokoroUrl: string;
   kokoroVoice: string;
-  kokoroApiType: string;
+  kokoroApiType: ApiType;
   setKokoroUrl: (key: string) => void;
   setSettingsUpdated: (updated: boolean) => void;
   setKokoroVoice: (key: string) => void;
-  setKokoroApiType: (key: string) => void;
+  setKokoroApiType: (key: ApiType) => void;
 }) {
   const { t } = useTranslation();
   const [voiceList, setVoiceList] = useState<{ key: string; label: string }[]>([]);
@@ -41,7 +41,7 @@ export function KokoroSettingsPage({
       }
     }
     fetchVoiceList();
-  }, []);
+  }, [kokoroApiType, kokoroUrl]);
 
   return (
     <BasicPage

--- a/src/components/settings/KokoroSettingsPage.tsx
+++ b/src/components/settings/KokoroSettingsPage.tsx
@@ -8,15 +8,19 @@ import { kokoroVoiceList } from '@/features/kokoro/kokoro';
 export function KokoroSettingsPage({
   kokoroUrl,
   kokoroVoice,
+  kokoroApiType,
   setKokoroUrl,
   setKokoroVoice,
+  setKokoroApiType,
   setSettingsUpdated,
 }: {
   kokoroUrl: string;
   kokoroVoice: string;
+  kokoroApiType: string;
   setKokoroUrl: (key: string) => void;
   setSettingsUpdated: (updated: boolean) => void;
   setKokoroVoice: (key: string) => void;
+  setKokoroApiType: (key: string) => void;
 }) {
   const { t } = useTranslation();
   const [voiceList, setVoiceList] = useState<{ key: string; label: string }[]>([]);
@@ -50,6 +54,28 @@ export function KokoroSettingsPage({
         </NotUsingAlert>
       ) }
       <ul role="list" className="divide-y divide-gray-100 max-w-xs">
+        <li className="py-4">
+          <FormRow label={t("API Type")}>
+            <select
+              className="mt-2 block w-full rounded-md border-0 py-1.5 pl-3 pr-10 text-gray-900 ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-indigo-600 sm:text-sm sm:leading-6"
+              value={kokoroApiType}
+              onChange={(event: React.ChangeEvent<any>) => {
+                const value = event.target.value;
+                setKokoroApiType(value);
+                updateConfig("kokoro_api_type", value);
+                setSettingsUpdated(true);
+              }}
+            >
+              <option value="standard">Standard Kokoro</option>
+              <option value="fastapi">Kokoro FastAPI</option>
+            </select>
+            <p className="mt-2 text-sm text-gray-500">
+              {kokoroApiType === "fastapi"
+                ? "Using OpenAI-compatible FastAPI endpoint (e.g., http://localhost:8880)"
+                : "Using standard Kokoro endpoint (e.g., http://localhost:8080)"}
+            </p>
+          </FormRow>
+        </li>
         <li className="py-4">
           <FormRow label={t("URL")}>
             <TextInput

--- a/src/components/settings/KokoroSettingsPage.tsx
+++ b/src/components/settings/KokoroSettingsPage.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { BasicPage, FormRow, NotUsingAlert } from './common';
 import { TextInput } from "@/components/textInput";
 import { config, updateConfig } from "@/utils/config";
-import { kokoroVoiceList, type ApiType } from '@/features/kokoro/kokoro';
+import { kokoroVoiceList, type KokoroApiType } from '@/features/kokoro/kokoro';
 
 export function KokoroSettingsPage({
   kokoroUrl,
@@ -16,11 +16,11 @@ export function KokoroSettingsPage({
 }: {
   kokoroUrl: string;
   kokoroVoice: string;
-  kokoroApiType: ApiType;
+  kokoroApiType: KokoroApiType;
   setKokoroUrl: (key: string) => void;
   setSettingsUpdated: (updated: boolean) => void;
   setKokoroVoice: (key: string) => void;
-  setKokoroApiType: (key: ApiType) => void;
+  setKokoroApiType: (key: KokoroApiType) => void;
 }) {
   const { t } = useTranslation();
   const [voiceList, setVoiceList] = useState<{ key: string; label: string }[]>([]);

--- a/src/features/kokoro/kokoro.ts
+++ b/src/features/kokoro/kokoro.ts
@@ -1,6 +1,6 @@
 import { config } from '@/utils/config';
 
-type ApiType = 'standard' | 'fastapi';
+export type ApiType = 'standard' | 'fastapi';
 
 const apiConfigs: Record<ApiType, {
   ttsEndpoint: (url: string) => string;
@@ -36,7 +36,8 @@ const apiConfigs: Record<ApiType, {
 };
 
 async function fetchAudio(message: string): Promise<ArrayBuffer> {
-  const apiType = config("kokoro_api_type") as ApiType;
+  const rawType = config("kokoro_api_type");
+  const apiType: ApiType = rawType === "fastapi" ? "fastapi" : "standard";
   const apiConfig = apiConfigs[apiType];
   const url = config("kokoro_url");
   const voice = config("kokoro_voice");
@@ -56,7 +57,8 @@ async function fetchAudio(message: string): Promise<ArrayBuffer> {
 }
 
 async function fetchVoiceList(): Promise<{ voices: string[] }> {
-  const apiType = config("kokoro_api_type") as ApiType;
+  const rawType = config("kokoro_api_type");
+  const apiType: ApiType = rawType === "fastapi" ? "fastapi" : "standard";
   const apiConfig = apiConfigs[apiType];
   const url = config("kokoro_url");
 
@@ -64,6 +66,11 @@ async function fetchVoiceList(): Promise<{ voices: string[] }> {
     method: 'GET',
     headers: { 'Accept': apiConfig.voicesAccept },
   });
+
+  if (!response.ok) {
+    console.error(response);
+    throw new Error("Kokoro TTS API Error");
+  }
 
   const data = await response.json();
   return apiConfig.parseVoiceList(data);

--- a/src/features/kokoro/kokoro.ts
+++ b/src/features/kokoro/kokoro.ts
@@ -1,46 +1,88 @@
 import { config } from '@/utils/config';
 
-export async function kokoro(
-  message: string,
-) {
-  try {
-    const res = await fetch(`${config("kokoro_url")}/tts`, {
-      method: "POST",
-      body: JSON.stringify({
-        text: message,
-        voice: config("kokoro_voice"),
-      }),
-      headers: {
-        "Content-Type": "application/json",
-      },
-    });
-    if (! res.ok) {
-      console.error(res);
-      throw new Error("Kokoro TTS API Error");
-    }
-    const data = (await res.arrayBuffer()) as any;
+type ApiType = 'standard' | 'fastapi';
 
-    return { audio: data };
+const apiConfigs: Record<ApiType, {
+  ttsEndpoint: (url: string) => string;
+  ttsBody: (message: string, voice: string) => Record<string, unknown>;
+  voicesEndpoint: (url: string) => string;
+  voicesAccept: string;
+  parseVoiceList: (data: any) => { voices: string[] };
+}> = {
+  standard: {
+    ttsEndpoint: (url) => `${url}/tts`,
+    ttsBody: (message, voice) => ({ text: message, voice }),
+    voicesEndpoint: (url) => `${url}/voices`,
+    voicesAccept: "application/text",
+    parseVoiceList: (data) => data,
+  },
+  fastapi: {
+    ttsEndpoint: (url) => `${url}/v1/audio/speech`,
+    ttsBody: (message, voice) => ({
+      input: message,
+      voice,
+      model: "kokoro",
+      response_format: "wav",
+    }),
+    voicesEndpoint: (url) => `${url}/v1/audio/voices`,
+    voicesAccept: "application/json",
+    parseVoiceList: (data) => {
+      if (data?.data && Array.isArray(data.data)) {
+        return { voices: data.data.map((voice: any) => voice.id) };
+      }
+      return data;
+    },
+  },
+};
+
+async function fetchAudio(message: string): Promise<ArrayBuffer> {
+  const apiType = config("kokoro_api_type") as ApiType;
+  const apiConfig = apiConfigs[apiType];
+  const url = config("kokoro_url");
+  const voice = config("kokoro_voice");
+
+  const res = await fetch(apiConfig.ttsEndpoint(url), {
+    method: "POST",
+    body: JSON.stringify(apiConfig.ttsBody(message, voice)),
+    headers: { "Content-Type": "application/json" },
+  });
+
+  if (!res.ok) {
+    console.error(res);
+    throw new Error("Kokoro TTS API Error");
+  }
+
+  return (await res.arrayBuffer()) as any;
+}
+
+async function fetchVoiceList(): Promise<{ voices: string[] }> {
+  const apiType = config("kokoro_api_type") as ApiType;
+  const apiConfig = apiConfigs[apiType];
+  const url = config("kokoro_url");
+
+  const response = await fetch(apiConfig.voicesEndpoint(url), {
+    method: 'GET',
+    headers: { 'Accept': apiConfig.voicesAccept },
+  });
+
+  const data = await response.json();
+  return apiConfig.parseVoiceList(data);
+}
+
+export async function kokoro(message: string) {
+  try {
+    const audio = await fetchAudio(message);
+    return { audio };
   } catch (e) {
     console.error('ERROR', e);
     throw new Error("Kokoro TTS API Error");
   }
 }
 
-export async function kokoroVoiceList(
-) {
+export async function kokoroVoiceList() {
   try {
-    const response = await fetch(`${config("kokoro_url")}/voices`, {
-      method: 'GET',
-      headers: {
-        'Accept': "application/text",
-      }
-    })
-
-    return response.json();
-
+    return await fetchVoiceList();
   } catch (error) {
-
     console.error('Error fetching kokoro voice:', error);
     throw error;
   }

--- a/src/features/kokoro/kokoro.ts
+++ b/src/features/kokoro/kokoro.ts
@@ -1,8 +1,8 @@
 import { config } from '@/utils/config';
 
-export type ApiType = 'standard' | 'fastapi';
+export type KokoroApiType = 'standard' | 'fastapi';
 
-const apiConfigs: Record<ApiType, {
+const apiConfigs: Record<KokoroApiType, {
   ttsEndpoint: (url: string) => string;
   ttsBody: (message: string, voice: string) => Record<string, unknown>;
   voicesEndpoint: (url: string) => string;
@@ -37,7 +37,7 @@ const apiConfigs: Record<ApiType, {
 
 async function fetchAudio(message: string): Promise<ArrayBuffer> {
   const rawType = config("kokoro_api_type");
-  const apiType: ApiType = rawType === "fastapi" ? "fastapi" : "standard";
+  const apiType: KokoroApiType = rawType === "fastapi" ? "fastapi" : "standard";
   const apiConfig = apiConfigs[apiType];
   const url = config("kokoro_url");
   const voice = config("kokoro_voice");
@@ -58,7 +58,7 @@ async function fetchAudio(message: string): Promise<ArrayBuffer> {
 
 async function fetchVoiceList(): Promise<{ voices: string[] }> {
   const rawType = config("kokoro_api_type");
-  const apiType: ApiType = rawType === "fastapi" ? "fastapi" : "standard";
+  const apiType: KokoroApiType = rawType === "fastapi" ? "fastapi" : "standard";
   const apiConfig = apiConfigs[apiType];
   const url = config("kokoro_url");
 

--- a/src/features/kokoro/kokoro.ts
+++ b/src/features/kokoro/kokoro.ts
@@ -36,10 +36,18 @@ const apiConfigs: Record<KokoroApiType, {
     voicesAccept: "application/json",
     parseVoiceList: (data) => {
       if (data?.data && Array.isArray(data.data)) {
-        return { voices: data.data.map((voice: any) => voice.id) };
+        const validVoices = data.data
+          .filter((voice: any) => voice?.id && typeof voice.id === 'string')
+          .map((voice: any) => voice.id);
+        if (validVoices.length > 0) {
+          return { voices: validVoices };
+        }
       }
       if (data?.voices && Array.isArray(data.voices)) {
-        return { voices: data.voices };
+        const validVoices = data.voices.filter((voice: any) => typeof voice === 'string');
+        if (validVoices.length > 0) {
+          return { voices: validVoices };
+        }
       }
       return { voices: [] };
     },
@@ -64,7 +72,7 @@ async function fetchAudio(message: string): Promise<ArrayBuffer> {
     throw new Error("Kokoro TTS API Error");
   }
 
-  return (await res.arrayBuffer()) as any;
+  return await res.arrayBuffer();
 }
 
 async function fetchVoiceList(): Promise<{ voices: string[] }> {
@@ -93,7 +101,7 @@ export async function kokoro(message: string) {
     return { audio };
   } catch (e) {
     console.error('ERROR', e);
-    throw new Error("Kokoro TTS API Error");
+    throw new Error(`Kokoro TTS API Error: ${e instanceof Error ? e.message : String(e)}`);
   }
 }
 

--- a/src/features/kokoro/kokoro.ts
+++ b/src/features/kokoro/kokoro.ts
@@ -14,7 +14,12 @@ const apiConfigs: Record<KokoroApiType, {
     ttsBody: (message, voice) => ({ text: message, voice }),
     voicesEndpoint: (url) => `${url}/voices`,
     voicesAccept: "application/text",
-    parseVoiceList: (data) => data,
+    parseVoiceList: (data) => {
+      if (data?.voices && Array.isArray(data.voices)) {
+        return data;
+      }
+      return { voices: [] };
+    },
   },
   fastapi: {
     ttsEndpoint: (url) => `${url}/v1/audio/speech`,
@@ -30,7 +35,7 @@ const apiConfigs: Record<KokoroApiType, {
       if (data?.data && Array.isArray(data.data)) {
         return { voices: data.data.map((voice: any) => voice.id) };
       }
-      return data;
+      return { voices: [] };
     },
   },
 };

--- a/src/features/kokoro/kokoro.ts
+++ b/src/features/kokoro/kokoro.ts
@@ -18,6 +18,9 @@ const apiConfigs: Record<KokoroApiType, {
       if (data?.voices && Array.isArray(data.voices)) {
         return data;
       }
+      if (Array.isArray(data)) {
+        return { voices: data };
+      }
       return { voices: [] };
     },
   },
@@ -34,6 +37,9 @@ const apiConfigs: Record<KokoroApiType, {
     parseVoiceList: (data) => {
       if (data?.data && Array.isArray(data.data)) {
         return { voices: data.data.map((voice: any) => voice.id) };
+      }
+      if (data?.voices && Array.isArray(data.voices)) {
+        return { voices: data.voices };
       }
       return { voices: [] };
     },

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -78,6 +78,7 @@ export const defaults = {
   coquiLocal_url: process.env.NEXT_PUBLIC_COQUILOCAL_URL ?? 'http://localhost:5002',
   coquiLocal_voiceid: process.env.NEXT_PUBLIC_COQUILOCAL_VOICEID ?? 'p240',
   kokoro_url: process.env.NEXT_PUBLIC_KOKORO_URL ?? 'http://localhost:8080',
+  kokoro_api_type: process.env.NEXT_PUBLIC_KOKORO_API_TYPE ?? 'standard',
   kokoro_voice: process.env.NEXT_PUBLIC_KOKORO_VOICE ?? 'af_bella',
   piper_url: process.env.NEXT_PUBLIC_PIPER_URL ?? 'https://i-love-amica.com:5000/tts',
   elevenlabs_apikey: process.env.NEXT_PUBLIC_ELEVENLABS_APIKEY ??'',


### PR DESCRIPTION
Add support for Kokoro-FastAPI alongside the standard Kokoro implementation. Users can now toggle between standard and FastAPI (OpenAI-compatible) endpoints in settings.

Changes:
- Add kokoro_api_type config key (default: 'standard')
- Implement conditional API routing in kokoro.ts
- Handle different voice list response formats for each API
- Add API type selector to KokoroSettingsPage with help text
- Integrate kokoroApiType state management in main settings

The implementation allows seamless switching between:
- Standard Kokoro: POST /tts endpoint
- Kokoro-FastAPI: POST /v1/audio/speech (OpenAI-compatible)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a settings option to choose between Standard Kokoro and Kokoro FastAPI for TTS.
  * Kokoro integration now supports multiple API types with unified voice listing and audio fetching.
  * Default Kokoro API type added to app configuration.

* **Bug Fixes**
  * Persisted API type selection and ensured voice list refreshes when the API type changes.
  * Fixed a formatting typo in settings configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->